### PR TITLE
Fix 401 errors by adding login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import GoogleAuthCallback from "./pages/GoogleAuthCallback";
+import Login from "./pages/Login";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/auth/google/callback" element={<GoogleAuthCallback />} />
+          <Route path="/login" element={<Login />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,9 +1,14 @@
 
-import { Building2, TrendingUp, Shield } from "lucide-react";
+import { Building2, TrendingUp, Shield, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { supabase } from "@/integrations/supabase/client";
 
 const DashboardHeader = () => {
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    window.location.href = "/login";
+  };
   return (
     <div className="bg-white rounded-xl shadow-sm border p-6">
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
@@ -29,6 +34,9 @@ const DashboardHeader = () => {
           <Button className="bg-blue-600 hover:bg-blue-700">
             <TrendingUp className="h-4 w-4 mr-2" />
             Exporter les données
+          </Button>
+          <Button variant="outline" onClick={handleLogout}>
+            <LogOut className="h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/src/components/GoogleAuth.tsx
+++ b/src/components/GoogleAuth.tsx
@@ -40,6 +40,11 @@ const GoogleAuth = () => {
   const connectGoogle = async () => {
     setIsLoading(true);
     try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        window.location.href = "/login";
+        return;
+      }
       // Rediriger vers l'OAuth Google
       const redirectUrl = `${window.location.origin}/auth/google/callback`;
       const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,7 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
 import DashboardHeader from "@/components/DashboardHeader";
 import KPICards from "@/components/KPICards";
 import ChartsSection from "@/components/ChartsSection";
@@ -9,6 +11,7 @@ import GoogleAuth from "@/components/GoogleAuth";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const Index = () => {
+  const navigate = useNavigate();
   const [filters, setFilters] = useState({
     city: "all",
     department: "all",
@@ -16,6 +19,14 @@ const Index = () => {
     minScore: 0,
     period: "30"
   });
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) {
+        navigate("/login");
+      }
+    });
+  }, [navigate]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin },
+    });
+
+    if (error) {
+      toast({
+        title: "Erreur",
+        description: error.message,
+        variant: "destructive",
+      });
+    } else {
+      toast({
+        title: "Lien envoyé",
+        description: "Vérifiez vos e-mails pour vous connecter",
+      });
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg space-y-4 shadow-md w-80">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" disabled={isLoading} className="w-full">
+          {isLoading ? "Envoi..." : "Envoyer le lien de connexion"}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- create a simple Login page that sends a magic link
- redirect anonymous users to Login
- add logout button
- guard Google auth connection when not logged in

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684aa1edb7588324b497db96c32ec9aa