### PR TITLE
Improve Google OAuth error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Google OAuth configuration
+
+Les fonctions Edge `google-oauth` et `sync-google-data` nécessitent plusieurs variables d'environnement pour fonctionner correctement. Assurez‑vous de définir les variables suivantes dans votre projet Supabase :
+
+```
+GOOGLE_CLIENT_ID=<id client Google>
+GOOGLE_CLIENT_SECRET=<secret client Google>
+GOOGLE_REDIRECT_URI=<URL de rappel utilisée pour l’authentification>
+```
+
+Ces valeurs doivent correspondre à la configuration de votre application Google Cloud et à l'URL utilisée lors de la redirection dans l'interface (`/auth/google/callback`).

--- a/supabase/functions/google-oauth/index.ts
+++ b/supabase/functions/google-oauth/index.ts
@@ -23,6 +23,14 @@ serve(async (req) => {
       }
     )
 
+    const googleClientId = Deno.env.get('GOOGLE_CLIENT_ID')
+    const googleClientSecret = Deno.env.get('GOOGLE_CLIENT_SECRET')
+    const googleRedirectUri = Deno.env.get('GOOGLE_REDIRECT_URI')
+
+    if (!googleClientId || !googleClientSecret || !googleRedirectUri) {
+      throw new Error('Variables d\'environnement Google OAuth manquantes')
+    }
+
     const { data: { user } } = await supabaseClient.auth.getUser()
     
     if (!user) {
@@ -52,11 +60,11 @@ serve(async (req) => {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: new URLSearchParams({
-        client_id: Deno.env.get('GOOGLE_CLIENT_ID') ?? '',
-        client_secret: Deno.env.get('GOOGLE_CLIENT_SECRET') ?? '',
+        client_id: googleClientId,
+        client_secret: googleClientSecret,
         code: code,
         grant_type: 'authorization_code',
-        redirect_uri: Deno.env.get('GOOGLE_REDIRECT_URI') ?? '',
+        redirect_uri: googleRedirectUri,
       }),
     })
 

--- a/supabase/functions/sync-google-data/index.ts
+++ b/supabase/functions/sync-google-data/index.ts
@@ -23,6 +23,13 @@ serve(async (req) => {
       }
     )
 
+    const googleClientId = Deno.env.get('GOOGLE_CLIENT_ID')
+    const googleClientSecret = Deno.env.get('GOOGLE_CLIENT_SECRET')
+
+    if (!googleClientId || !googleClientSecret) {
+      throw new Error('Variables d\'environnement Google OAuth manquantes')
+    }
+
     const { data: { user } } = await supabaseClient.auth.getUser()
     
     if (!user) {
@@ -50,8 +57,8 @@ serve(async (req) => {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: new URLSearchParams({
-            client_id: Deno.env.get('GOOGLE_CLIENT_ID') ?? '',
-            client_secret: Deno.env.get('GOOGLE_CLIENT_SECRET') ?? '',
+            client_id: googleClientId,
+            client_secret: googleClientSecret,
             refresh_token: account.refresh_token,
             grant_type: 'refresh_token',
           }),


### PR DESCRIPTION
## Summary
- add checks for missing Google OAuth environment variables in edge functions
- clarify required Google OAuth env vars in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684adaee20fc8324ac1aa5d8af7823b0